### PR TITLE
Simplified code

### DIFF
--- a/Tests/test_file_webp_alpha.py
+++ b/Tests/test_file_webp_alpha.py
@@ -123,7 +123,7 @@ def test_keep_rgb_values_when_transparent(tmp_path):
         # even though it is lossless, if we don't use exact=True
         # in libwebp >= 0.5, the transparent area will be filled with black
         # (or something more conducive to compression)
-        assert_image_similar(reloaded.convert("RGB"), image, 1)
+        assert_image_equal(reloaded.convert("RGB"), image)
 
 
 def test_write_unsupported_mode_PA(tmp_path):

--- a/src/PIL/WebPImagePlugin.py
+++ b/src/PIL/WebPImagePlugin.py
@@ -318,7 +318,7 @@ def _save(im, fp, filename):
         exif = exif[6:]
     xmp = im.encoderinfo.get("xmp", "")
     method = im.encoderinfo.get("method", 4)
-    exact = im.encoderinfo.get("exact", False)
+    exact = 1 if im.encoderinfo.get("exact") else 0
 
     if im.mode not in _VALID_WEBP_LEGACY_MODES:
         alpha = (
@@ -337,7 +337,7 @@ def _save(im, fp, filename):
         im.mode,
         icc_profile,
         method,
-        1 if exact else 0,
+        exact,
         exif,
         xmp,
     )


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/6747

- I've made a change to WebPImagePlugin, simplifying the code in my opinion.
- I was wondering why your test didn't fail on CentOS 7, until I realised the fill behaviour [only became the default in libwebp 0.5.0](https://github.com/webmproject/libwebp/blob/fad0ece7edec90dbead3cfbe19f2bc9d77a410e2/NEWS#L168). So I've noted that in the test.
- If you aren't on board with my stylistic changes to your test code, feel free to disagree.
- I found that our test suite passes if I check if the images are equal, not just similar. Did you find that it didn't pass in some environment, or were you just copying code from another test? I suspect that the `lossless` argument is what makes this pass.